### PR TITLE
Move Python virt. env to standard non devbox path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,19 @@ Example:
 This plugin has the baseline of tools needed for a DevOps project.
 
 This includes:
-  * Python, including a virtual environment
-  * Pre-commit and linting hooks
-  * tfswitch, tflint and terraform-docs for working with terraform
-  * Taskfile
+
+* Python, including a virtual environment
+* Pre-commit and linting hooks
+* tfswitch, tflint and terraform-docs for working with terraform
+* Taskfile
+
+Assumptions:
+
+* You use either Bash or Zsh as your shell.
 
 #### Python and pip
 
-The plugin creates a python virtual envrionment, activates it and installs pip requirements. Note that it expects a `requirements.txt` in the root of the project for pip installation to work. If your requirements file is located elsewhere, you can create a "root" requirements.txt with a link to your other requirements file.
+The plugin creates a python virtual environment, activates it and installs pip requirements. Note that it expects a `requirements.txt` in the root of the project for pip installation to work. If your requirements file is located elsewhere, you can create a "root" requirements.txt with a link to your other requirements file.
 
 Example `requirement.txt`:
 

--- a/devbox-plugins/base-config/plugin.json
+++ b/devbox-plugins/base-config/plugin.json
@@ -20,7 +20,17 @@
   "env": {
     // Remote taskfiles are an experimental feature in Taskfile, so it is enabled by setting a feature flag as an environment variable TASK_X_REMOTE_TASKFILES. More information about remote taskfiles and experiments can be found in https://taskfile.dev/experiments/remote-taskfiles/. Status of the experiment can be found in depth https://github.com/orgs/go-task/projects/1?pane=issue&itemId=37121354
     // While the feature is an experiment we expect it to be included at some point that is seems like a necessary feature.
-    "TASK_X_REMOTE_TASKFILES": "1"
+    "TASK_X_REMOTE_TASKFILES": "1",
+
+    // Change default location of virtual environment from devbox default VENV_DIR=.devbox/virtenv/python/.venv to `.venv`
+    // so we do not implicitly have other tools depend on devbox internal locations.
+    //
+    // Using `.venv` is more community like and standard for other tools to find.
+    // https://docs.python.org/3/tutorial/venv.html](https://docs.python.org/3/tutorial/venv.html writes:
+    // > A common directory location for a virtual environment is .venv. This name keeps the directory typically hidden in your shell
+    // > and thus out of the way while giving it a name that explains why the directory exists.
+    // It also prevents clashing with .env environment variable definition files that some tooling supports.
+    "VENV_DIR": ".venv"
   },
   // Remember to declare all files in this section, if you want to process them shell or scripts below.
   "create_files": {
@@ -36,7 +46,13 @@
   },
   "shell": {
     "init_hook": [
+      // Works for bash and zsh
       ". $VENV_DIR/bin/activate",
+
+      // try to make adding to .gitignore idempotent
+      // crudini tool tries to read from default section, as if was an ini file, and find the line starting with ".venv" and returns true if found
+      "if crudini --get .gitignore \"\" \".venv\";then true; else echo -e '\n\n# Python virtual environment for tooling and Ansible\n.venv' >> .gitignore; fi",
+
       "if [ -f requirements.txt ];then pip install -r requirements.txt;fi",
       "if [ -f .pre-commit-config.yaml ];then pre-commit install;fi"
     ],


### PR DESCRIPTION
Have devbox initialize the Python virtual environment to a more commonly
expected path, where tools automatically looks for such existence.

This also removes the implicit dependency other tools risk build on the
non standard default devbox virtual env. path.
