### PR TITLE
feat: Only use py virt env if requirements file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugin has the baseline of tools needed for a DevOps project.
 
 This includes:
 
-* Python, including a virtual environment
+* Python, including a virtual environment if `requirements.txt` is present in the root of the repository
 * Pre-commit and linting hooks
 * tfswitch, tflint and terraform-docs for working with terraform
 * Taskfile
@@ -43,7 +43,7 @@ Assumptions:
 
 #### Python and pip
 
-The plugin creates a python virtual environment, activates it and installs pip requirements. Note that it expects a `requirements.txt` in the root of the project for pip installation to work. If your requirements file is located elsewhere, you can create a "root" requirements.txt with a link to your other requirements file.
+The plugin creates a python virtual environment, activates it and installs pip requirements if `requirements.txt` exists in the root of the project. If your requirements file is located elsewhere, you can create a "root" requirements.txt with a link to your other requirements file.
 
 Example `requirement.txt`:
 

--- a/devbox-plugins/base-config/plugin.json
+++ b/devbox-plugins/base-config/plugin.json
@@ -46,14 +46,17 @@
   },
   "shell": {
     "init_hook": [
-      // Works for bash and zsh
-      ". $VENV_DIR/bin/activate",
+      // create virtual environment if requirements.txt exists
+      // 'activate' works for bash and zsh
+      "if [ -f requirements.txt ];then . $VENV_DIR/bin/activate;fi",
 
       // try to make adding to .gitignore idempotent
       // crudini tool tries to read from default section, as if was an ini file, and find the line starting with ".venv" and returns true if found
-      "if crudini --get .gitignore \"\" \".venv\";then true; else echo -e '\n\n# Python virtual environment for tooling and Ansible\n.venv' >> .gitignore; fi",
+      "if [ -f requirements.txt ]; then if crudini --get .gitignore \"\" \".venv\";then true; else echo -e '\n\n# Python virtual environment for tooling and Ansible\n.venv' >> .gitignore; fi; fi",
 
+      // install repository requirements, which might point to other requirements files
       "if [ -f requirements.txt ];then pip install -r requirements.txt;fi",
+
       "if [ -f .pre-commit-config.yaml ];then pre-commit install;fi"
     ],
     "scripts": {


### PR DESCRIPTION
Minor improvement to only source and use Python virtual environments if
there is a requirements.txt file that exists.
