### PR TITLE
feat: Include editorconfig in pre-commit and support CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Example:
 
 ### Base config
 
-This plugin has the baseline of tools needed for a DevOps project.
+This plugin has the baseline of tools needed for various DevOps projects.
 
 This includes:
 
 * Python, and activation of a virtual environment if `requirements.txt` is present in the root of the repository using this plugin
-* Pre-commit and linting hooks
+* Pre-commit and linting hooks, and CI Github actions for it.
 * tenv, tflint and terraform-docs for working with terraform or tofu
-* Taskfile
+* Taskfile or reusable tasks
 
 Assumptions:
 
@@ -77,7 +77,8 @@ The base config plugin includes some scripts to help bootstrap a new project.
 
 Available scripts:
   * __bootstrap-envrc-private__ - this command will setup direnv for using a private .envrc file
-  * __bootstrap-pre-commit__ - this command will create a basic pre-commit config with yamllint and tflint
+  * __bootstrap-pre-commit__ - this command will create a pre-commit config with lint and editorconfig
+  * __bootstrap-ci-lint__ - this command will add Github actions for linting with the same tools as pre-commit but on all files (not just changed ones). editorconfig-checker accepts a config file `.ecrc` but it doesn't have to exist.
   * __bootstrap-taskfile__ - this command will create a taskfile including common taskfile from the repo
   * __bootstrap-release-please__ - this command will create a release-please github action file using the __simple__ release type
   * __bootstrap-ansible__ - this command will create a basic ansible.cfg file and the `configure` folder

--- a/devbox-plugins/base-config/config/ci-lint.yml
+++ b/devbox-plugins/base-config/config/ci-lint.yml
@@ -1,0 +1,26 @@
+# This files was added by a devbox script from our devops tools project and is maintained there:
+# https://github.com/onlinecity/devops-tools
+# The file is added by bootstrap-editorconfig and bootstrap-pre-commit scripts
+# and supports conditionally both features.
+---
+name: CI
+
+on:
+  push:
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+        with:
+          enable-cache: "true"
+
+      - name: ensure pre-commit verifications
+        # we're not in an initialized devbox shell so need to run commands with devbox run --
+        # Notice also with -a to pre-commit we run all files, not only changed ones as this is a CI check
+        run: if [ -f .pre-commit-config.yaml ]; then devbox run -- pre-commit run -a; fi

--- a/devbox-plugins/base-config/config/pre-commit-config.yaml
+++ b/devbox-plugins/base-config/config/pre-commit-config.yaml
@@ -9,3 +9,11 @@ repos:
     rev: c9646748faf2914cbac342e9c06a7b5865d06d2f # v1.89.1
     hooks:
       - id: terraform_tflint
+  - repo: local
+    hooks:
+      - id: editorconfig-checker
+        name: Check editorconfig is followed
+        description: This hooks run editorconfig checking, ensuring editorconfig is followed in case the IDE doesn't do it automatically
+        # editorconfig-checker accepts a config file `.ecrc` but it doesn't have to exist.
+        entry: editorconfig-checker --config .ecrc
+        language: system

--- a/devbox-plugins/base-config/plugin.json
+++ b/devbox-plugins/base-config/plugin.json
@@ -17,7 +17,13 @@
     // for merging ini, ssh and lines, see https://github.com/pixelb/crudini
     // added to merge ansible.cfg files
     "crudini@0.9.5",
-    "yq-go@4.44.1"
+    "yq-go@4.44.1",
+    // Use with ci or cmd line to check files honor .editorconfig
+    // Multiple checkers are available, but the chosen one below seems to be the only mature and maintained one
+    // from this FAQ list: https://github.com/editorconfig/editorconfig/wiki/FAQ#are-there-any-tools-to-check-orand-reformat-existing-files-against-editorconfig-rules
+    // https://github.com/editorconfig-checker/editorconfig-checker
+    // Megalinter supports editorconfig, but couldn't find Nix package for megalinter: https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#mega-linter
+    "editorconfig-checker@3.0.3"
   ],
   "env": {
     // Remote taskfiles are an experimental feature in Taskfile, so it is enabled by setting a feature flag as an environment
@@ -48,6 +54,7 @@
     "{{ .Virtenv }}/.yamllint": "config/.yamllint",
     "{{ .Virtenv }}/taskfile.yml": "config/taskfile.yml",
     "{{ .Virtenv }}/.editorconfig": "config/.editorconfig",
+    "{{ .Virtenv }}/ci-lint.yml": "config/ci-lint.yml",
     "{{ .Virtenv }}/release-please.yml": "config/release-please.yml",
     "{{ .Virtenv }}/dependabot-gitsubmodules.yml": "config/dependabot-gitsubmodules.yml",
     "{{ .Virtenv }}/ansible.cfg": "config/ansible.cfg",
@@ -105,10 +112,11 @@
         "cp {{ .Virtenv }}/.yamllint .yamllint",
         "echo 'Bootstrapping done'"
       ],
-      "bootstrap-editorconfig": [
-        "echo 'Bootstrapping editorconfig'",
-        "cp {{ .Virtenv }}/.editorconfig .editorconfig",
-        "echo 'Bootstrapping editorconfig done'"
+      "bootstrap-ci-lint": [
+        "echo 'Bootstrapping CI lint actions'",
+        "mkdir -p .github/workflows",
+        "cp {{ .Virtenv }}/ci-lint.yml .github/workflows/ci-lint.yml",
+        "echo 'Bootstrapping CI lint actions done'"
       ],
       "bootstrap-taskfile": [
         "echo 'Bootstrapping taskfile'",


### PR DESCRIPTION
Editorconfig can as well run in pre-commit and we should use the same
tools and checks for CI lint afterwards. Bootstrap command can enable
this now.
