### PR TITLE
fix: Ensure .editorconfig is added for pre-commit

### DIFF
--- a/devbox-plugins/base-config/config/ci-lint.yml
+++ b/devbox-plugins/base-config/config/ci-lint.yml
@@ -1,6 +1,6 @@
 # This files was added by a devbox script from our devops tools project and is maintained there:
 # https://github.com/onlinecity/devops-tools
-# The file is added by bootstrap-editorconfig and bootstrap-pre-commit scripts
+# The file is added by bootstrap-ci-lint devbox script
 # and supports conditionally both features.
 ---
 name: CI

--- a/devbox-plugins/base-config/plugin.json
+++ b/devbox-plugins/base-config/plugin.json
@@ -109,6 +109,7 @@
         "echo 'Bootstrapping pre-commit'",
         "cp {{ .Virtenv }}/pre-commit-config.yaml .pre-commit-config.yaml",
         "cp {{ .Virtenv }}/.yamllint .yamllint",
+        "cp {{ .Virtenv }}/.editorconfig .editorconfig",
         "echo 'Bootstrapping done'"
       ],
       "bootstrap-ci-lint": [


### PR DESCRIPTION
When bootstrapping pre-commit feature, we also run editorconfig check
but the common .editorconfig file was not copied to the project so
others might have been used.
