### PR TITLE
Add jmespath to Ansible common requirements file

### DIFF
--- a/devbox-plugins/base-config/config/ansible-requirements.txt.dist
+++ b/devbox-plugins/base-config/config/ansible-requirements.txt.dist
@@ -8,3 +8,7 @@ ansible-core==2.17.1
 # https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_inventory.html#ansible-collections-hetzner-hcloud-hcloud-inventory-requirements
 # Error msg snippet if not installed:[WARNING]:  * Failed to parse ... inventories/stg/hcloud.yml with auto plugin: The Hetzner Cloud dynamic inventory plugin requires requests.
 hcloud>=1.0.0
+
+# Added to be able to work with json_query filter in Ansible, initially for parsing json output in our verifications.
+# https://docs.ansible.com/ansible/latest/collections/community/general/docsite/filter_guide_selecting_json_data.html
+jmespath==1.0.1


### PR DESCRIPTION
This adds another common Python package requirement to our Ansible
environments we expect to use in all projects.
