### PR TITLE
feat: Setup ansible factcache

### DIFF
--- a/devbox-plugins/base-config/config/ansible.cfg.dist
+++ b/devbox-plugins/base-config/config/ansible.cfg.dist
@@ -19,6 +19,7 @@ collections_path = ./
 # Cache facts in a /tmp/onlinecity_ansible_fact_cache/<ansible_hostname> file for. After 28800 seconds, gather facts will run again automatically.
 # To remove cached facts, one can simply just delete the files in /tmp/onlinecity_ansible_fact_cache/<ansible_hostname>
 # or run "task devops-tools:ssh-write-config-files" in the right provision project folder.
+# The path to fact_caching_connection is also used in the task-script of `task devops-tools:ssh-write-config-files` which also clear the fact-cache for ansible.
 fact_caching = community.general.yaml
 fact_caching_connection = /tmp/onlinecity_ansible_fact_cache
 fact_caching_timeout = 28800

--- a/devbox-plugins/base-config/config/ansible.cfg.dist
+++ b/devbox-plugins/base-config/config/ansible.cfg.dist
@@ -15,5 +15,15 @@ roles_path= ./roles
 # Installs collections into [current dir]/ansible_collections/namespace/collection_name
 collections_path = ./
 
+
+# Cache facts in a /tmp/onlinecity_ansible_fact_cache/<ansible_hostname> file for. After 28800 seconds, gather facts will run again automatically.
+# To remove cached facts, one can simply just delete the files in /tmp/onlinecity_ansible_fact_cache/<ansible_hostname>
+# or run "task devops-tools:ssh-write-config-files" in the right provision project folder.
+fact_caching = community.general.yaml
+fact_caching_connection = /tmp/onlinecity_ansible_fact_cache
+fact_caching_timeout = 28800
+gathering = smart
+
+
 [diff]
 always = true

--- a/devbox-plugins/base-config/config/ssh_host_connection_configuration_write_files.py
+++ b/devbox-plugins/base-config/config/ssh_host_connection_configuration_write_files.py
@@ -35,6 +35,9 @@ parser.add_argument('-c', '--config_dir', help='The output directory for the ssh
 parser.add_argument('-k', '--known_hosts_dir', help='The output directory for the known_hosts files for the hosts, pointed to from within the host configuration files.', required=False, metavar=".ssh/known_hosts.d/")
 args = parser.parse_args()
 
+# Path to ansible fact cache directory, where we store the ansible facts for the hosts.
+# They are hardcoded in https://github.com/onlinecity/devops-tools to be saved in /tmp/onlinecity_ansible_fact_cache/<vm_name>
+ansible_fact_cache_dir = "/tmp/onlinecity_ansible_fact_cache"
 
 # we distribute the templates with this script itself:
 template_dir = os.path.abspath(os.path.dirname(__file__) + "/ssh_host_connection_configuration_templates")
@@ -89,3 +92,8 @@ for hosts in json_data["hosts"]["value"]:
         with open(ssh_knownhost_filename, mode='w', encoding='utf-8') as document:
             document.write(content)
         os.chmod(ssh_knownhost_filename, 0o644)
+
+        # When writing new files for newly created hosts (or replaced, if tofu destro/apply), we also want to remove the cached ansible facts.
+        # They are hardcoded in https://github.com/onlinecity/devops-tools to be saved in /tmp/onlinecity_ansible_fact_cache/<vm_name>
+        if os.path.exists(ansible_fact_cache_dir + "/" + vm_name):
+            os.remove(ansible_fact_cache_dir + "/" + vm_name)


### PR DESCRIPTION
Setting factcaching to 8 hours, after https://github.com/onlinecity/ansible-common/pull/65
was merged, as this also improves running time of our playbooks.

The task script, to write SSH config and known hosts files, will now
delete existing fact_cache files from
/tmp/onlinecity_onlinecity_ansible_fact_cache/ so in the case of new
remote hosts, cached facts are deletes, and they will be gathered by
ansible on the next run.

Update devbox.json to use the new version of the plugin, mnost likely that would be v3.2.0, but lets see, which version it ends up with.

To enable these scripts, and fact_cache timeouts, simply just run from
the root of the repository:
devbox update
devbox run bootstrap-ansible

You also might want to remove the fact_caching section from
configure/ansible.cfg.local, in the repository.
