### PR TITLE
fix: use go template escape in release please file

### DIFF
--- a/devbox-plugins/base-config/config/release-please.yml
+++ b/devbox-plugins/base-config/config/release-please.yml
@@ -18,5 +18,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN  }}
+          token: {{"${{ secrets.GITHUB_TOKEN  }}"}}
           release-type: simple


### PR DESCRIPTION
The the template release please github action file, escape the double
curly with go template, because create_files runs these files through go
templating

The result, in the consumers of the plugin will be:

token: ${{ secrets.GITHUB_TOKEN  }}
