### PR TITLE
feat: ensure git submodules are not empty

### DIFF
--- a/devbox-plugins/base-config/plugin.json
+++ b/devbox-plugins/base-config/plugin.json
@@ -97,7 +97,9 @@
       "export PATH=\"$PWD/.aliases\":$PATH",
       "if crudini --get .gitignore \"\" \".aliases\";then true; else echo -e '\n\n# Aliases dir with script for devbox\n.aliases' >> .gitignore; fi",
       // run the different alias scripts:
-      "bash {{ .Virtenv }}/alias-terraform-tofu-init.sh"
+      "bash {{ .Virtenv }}/alias-terraform-tofu-init.sh",
+      // ensure git submodules are initialized and updated so we don't have empty submodule dirs (exits clean if no submodules are present) - also merge any local commits to the update as they would else be detached
+      "git submodule update --init --recursive --merge"
     ],
     "scripts": {
       "bootstrap-envrc-private": [


### PR DESCRIPTION
Ensure Git submodules are initialised and updated to match what the superproject expects.

`--merge` to not throw away any local changes, which there might be when working on new features.

Task: ONL-28045