### PR TITLE
feat: Add dnspython for community.general.dig lookup

### DIFF
--- a/devbox-plugins/base-config/config/ansible-requirements.txt.dist
+++ b/devbox-plugins/base-config/config/ansible-requirements.txt.dist
@@ -15,3 +15,7 @@ jmespath==1.0.1
 
 # For gcloud auth as Ansible operator to interfact with our Google Cloud services
 google-auth>=1.3.0
+
+# For the community.general.dig lookup plugin, used to find the public IP adress for a host,
+# when running the firewallscan container in the verify step of ansible-common.
+dnspython>=2.7.0


### PR DESCRIPTION
The firewallscan container in ansible-common needs the public IP address
to scan the host, and not the hostname.

It was changed from using the configured IP address on the host, but on
GCP hosts, the configured IP address is an internal RFC1918 address, and
it cannot be scanned from the operator host.

So we need to lookup the public IP address, from the hostname, and this
uses the ansible lookup plugin community.general.dig, which uses the
python library dnspython.
