### PR TITLE
fix: Fix typo in file extension

### DIFF
--- a/taskfile/taskfile.yml
+++ b/taskfile/taskfile.yml
@@ -15,8 +15,8 @@ tasks:
     desc: Run ansible galaxy install
     summary: |
       Run ansible-galaxy to install required packages
-      Expects a requirements.yaml in the root of the project
-    cmd: ansible-galaxy install -r requirements.yaml
+      Expects a requirements.yml in the root of the project
+    cmd: ansible-galaxy install -r requirements.yml
     dir: '{{.USER_WORKING_DIR}}'
 
   install-tofu:


### PR DESCRIPTION
Fix typo in file extension to fix error when running:
task devops-tools:ansible-galaxy